### PR TITLE
fix(docker): bigger ubi image in Dockerfile

### DIFF
--- a/zammad-ai-index/Dockerfile
+++ b/zammad-ai-index/Dockerfile
@@ -1,5 +1,5 @@
 # Smallest ubi10 image
-FROM registry.access.redhat.com/ubi10/ubi-micro:latest@sha256:f86852f349dcd2b9ebccef4c8a46fdb75ff2fef9fde8581cef1feddb706be7ba
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest@sha256:b01cbd6a4c538ea1002ca774d5e09adcae15a1c095804400ea201ea5811431b1
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:3b7b60a81d3c57ef471703e5c83fd4aaa33abcd403596fb22ab07db85ae91347 /uv /uvx /bin/
 

--- a/zammad-ai-index/pyproject.toml
+++ b/zammad-ai-index/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zammad-ai-index"
-version = "0.1.0"
+version = "0.1.1"
 description = "Indexing job for Zammad AI"
 readme = "README.md"
 requires-python = "==3.14.4"

--- a/zammad-ai-index/uv.lock
+++ b/zammad-ai-index/uv.lock
@@ -1151,7 +1151,7 @@ wheels = [
 
 [[package]]
 name = "zammad-ai-index"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "feedparser" },


### PR DESCRIPTION
Change ubi image because `micro` is not enough for numpy