### PR TITLE
fix(qdrant): only warn when the qdrant is empty

### DIFF
--- a/zammad-ai-workflow/app/answer/knowledgebase.py
+++ b/zammad-ai-workflow/app/answer/knowledgebase.py
@@ -100,7 +100,6 @@ class QdrantKBClient:
             )
             if collection_info.points_count == 0:
                 self.logger.warning(f"Qdrant collection '{qdrant_settings.collection_name}' exists but is empty.")
-                raise QdrantKBError(f"Qdrant collection '{qdrant_settings.collection_name}' exists but is empty.")
 
         except ApiException as e:
             self.logger.error("Error checking Qdrant collection existence or retrieving collection info", exc_info=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty knowledge base collections - the system now logs a warning and allows the application to continue operating instead of stopping initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/zammad-ai/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->