### PR TITLE
feat(jinja): add today as variable

### DIFF
--- a/zammad-ai-workflow/app/answer/agent.py
+++ b/zammad-ai-workflow/app/answer/agent.py
@@ -131,7 +131,6 @@ def build_agent(
         temperature=genai_settings.answer_temperature,
         max_retries=genai_settings.max_retries,
         reasoning=genai_settings.answer_reasoning_config,
-        store=genai_settings.answer_store,
     )
 
     # Configure the tools

--- a/zammad-ai-workflow/app/answer/judge.py
+++ b/zammad-ai-workflow/app/answer/judge.py
@@ -37,7 +37,6 @@ class JudgeHandler:
                     temperature=genai_settings.judge_temperature,
                     max_retries=genai_settings.max_retries,
                     reasoning=genai_settings.judge_reasoning_config,
-                    store=genai_settings.judge_store,
                 )
             case _:
                 raise ValueError(f"Unsupported GenAI SDK: {genai_settings.sdk}")

--- a/zammad-ai-workflow/app/settings/genai.py
+++ b/zammad-ai-workflow/app/settings/genai.py
@@ -75,13 +75,6 @@ class GenAISettings(BaseModel):
     )
 
     @property
-    def triage_store(self) -> bool | None:
-        """Determines whether to store interactions based on the configured GenAI SDK."""
-        if self.triage_reasoning_effort is not None:
-            return False
-        return None
-
-    @property
     def triage_reasoning_config(self) -> dict[str, str] | None:
         """Constructs a reasoning configuration dictionary for LLM interactions based on the configured reasoning effort."""
         if self.triage_reasoning_effort is not None:
@@ -91,12 +84,6 @@ class GenAISettings(BaseModel):
             }
         return None
 
-    @property
-    def answer_store(self) -> bool | None:
-        """Determines whether to store interactions based on the configured GenAI SDK."""
-        if self.answer_reasoning_effort is not None:
-            return False
-        return None
 
     @property
     def answer_reasoning_config(self) -> dict[str, str] | None:
@@ -106,13 +93,6 @@ class GenAISettings(BaseModel):
                 "effort": self.answer_reasoning_effort,
                 "summary": "detailed",
             }
-        return None
-
-    @property
-    def judge_store(self) -> bool | None:
-        """Determines whether to store interactions based on the configured GenAI SDK."""
-        if self.judge_reasoning_effort is not None:
-            return False
         return None
 
     @property

--- a/zammad-ai-workflow/app/triage/genai_handler.py
+++ b/zammad-ai-workflow/app/triage/genai_handler.py
@@ -78,7 +78,6 @@ class GenAIHandler:
                     temperature=genai_settings.triage_temperature,
                     max_retries=genai_settings.max_retries,
                     reasoning=genai_settings.triage_reasoning_config,
-                    store=genai_settings.triage_store,
                 )
             case _:
                 raise ValueError(f"Unsupported GenAI SDK: {genai_settings.sdk}")

--- a/zammad-ai-workflow/app/triage/triage.py
+++ b/zammad-ai-workflow/app/triage/triage.py
@@ -1,6 +1,6 @@
 """Core triage service for ticket categorization and action selection."""
 
-from datetime import date
+from datetime import datetime, timezone
 from time import perf_counter
 
 from dotenv import load_dotenv
@@ -396,10 +396,12 @@ class TriageService:
                         for condition in conditions:
                             if condition.field == "days_since_request":
                                 if days_since_request is None:
-                                    days_result: DaysSinceRequestResponse = await self.genai_handler.extract_days_since_request(
-                                        message=message,
-                                        today=date.today().isoformat(),  # TODO: Mpck date for benchmarks with old tickets
-                                        session_id=session_id,
+                                    days_result: DaysSinceRequestResponse = (
+                                        await self.genai_handler.extract_days_since_request(
+                                            message=message,
+                                            today=datetime.now(timezone.utc).date().isoformat(),
+                                            session_id=session_id,
+                                        )
                                     )
                                     days_since_request = days_result.days_since_request
                                 if (get_operator_function(operator=condition.operator))(

--- a/zammad-ai-workflow/app/utils/context_builders.py
+++ b/zammad-ai-workflow/app/utils/context_builders.py
@@ -10,7 +10,7 @@ thresholds, tool lists) while LangChain variables (like {text}, {categories})
 are used for PER-REQUEST data.
 """
 
-from datetime import date
+from datetime import datetime, timezone
 from typing import Any
 
 from app.models.triage import Category
@@ -65,7 +65,7 @@ def build_triage_context(
             for c in categories
         ],
         # Provide today's date (ISO format) for prompts that need to reference the current day
-        "today": date.today().isoformat(),
+        "today": datetime.now(timezone.utc).date().isoformat(),
     }
 
 
@@ -103,7 +103,7 @@ def build_answer_context(
         "disclaimer": settings.ai_answer_disclaimer,
         "retrieval_num_documents": settings.qdrant.retrieval_num_documents,
         # Provide today's date (ISO format) for prompts that need to reference the current day
-        "today": date.today().isoformat(),
+        "today": datetime.now(timezone.utc).date().isoformat(),
     }
 
 
@@ -140,7 +140,7 @@ def build_judge_context(
         "repair_enabled": judge_settings.enabled and judge_settings.max_repairs > 0,
         "max_repairs": judge_settings.max_repairs,
         # Provide today's date (ISO format) for prompts that need to reference the current day
-        "today": date.today().isoformat(),
+        "today": datetime.now(timezone.utc).date().isoformat(),
     }
 
 

--- a/zammad-ai-workflow/app/utils/context_builders.py
+++ b/zammad-ai-workflow/app/utils/context_builders.py
@@ -10,6 +10,7 @@ thresholds, tool lists) while LangChain variables (like {text}, {categories})
 are used for PER-REQUEST data.
 """
 
+from datetime import date
 from typing import Any
 
 from app.models.triage import Category
@@ -63,6 +64,8 @@ def build_triage_context(
             }
             for c in categories
         ],
+        # Provide today's date (ISO format) for prompts that need to reference the current day
+        "today": date.today().isoformat(),
     }
 
 
@@ -99,6 +102,8 @@ def build_answer_context(
         "dlf_enabled": settings.dlf is not None,
         "disclaimer": settings.ai_answer_disclaimer,
         "retrieval_num_documents": settings.qdrant.retrieval_num_documents,
+        # Provide today's date (ISO format) for prompts that need to reference the current day
+        "today": date.today().isoformat(),
     }
 
 
@@ -134,6 +139,8 @@ def build_judge_context(
         },
         "repair_enabled": judge_settings.enabled and judge_settings.max_repairs > 0,
         "max_repairs": judge_settings.max_repairs,
+        # Provide today's date (ISO format) for prompts that need to reference the current day
+        "today": date.today().isoformat(),
     }
 
 

--- a/zammad-ai-workflow/app/utils/context_builders.py
+++ b/zammad-ai-workflow/app/utils/context_builders.py
@@ -52,6 +52,8 @@ def build_triage_context(
         >>> # Pass to Jinja2 renderer
         >>> renderer.render_template(triage_prompt, context)
     """
+    today: date = date.today()
+    today_str: str = f"{today.isoformat()}, {today.strftime('%A')}, KW{today.isocalendar().week:02d}"
     return {
         "knowledge_base_enabled": bool(settings.answer.qdrant.collection_name),
         "dlf_enabled": settings.answer.dlf is not None,
@@ -64,8 +66,8 @@ def build_triage_context(
             }
             for c in categories
         ],
-        # Provide today's date (ISO format) for prompts that need to reference the current day
-        "today": date.today().isoformat(),
+        # Provide today's date (ISO format + weekday + calendar week) for prompts that need to reference the current day
+        "today": today_str,
     }
 
 
@@ -96,14 +98,17 @@ def build_answer_context(
     """
     tools = _build_tool_definitions(settings)
 
+    today: date = date.today()
+    today_str: str = f"{today.isoformat()}, {today.strftime('%A')}, KW{today.isocalendar().week:02d}"
+
     return {
         "available_tools": [{"name": tool.name, "description": tool.description} for tool in tools],
         "knowledge_base_enabled": bool(settings.qdrant.collection_name),
         "dlf_enabled": settings.dlf is not None,
         "disclaimer": settings.ai_answer_disclaimer,
         "retrieval_num_documents": settings.qdrant.retrieval_num_documents,
-        # Provide today's date (ISO format) for prompts that need to reference the current day
-        "today": date.today().isoformat(),
+        # Provide today's date (ISO format + weekday + calendar week) for prompts that need to reference the current day
+        "today": today_str,
     }
 
 
@@ -131,6 +136,9 @@ def build_judge_context(
     """
     judge_settings = settings.answer.judge
 
+    today: date = date.today()
+    today_str: str = f"{today.isoformat()}, {today.strftime('%A')}, KW{today.isocalendar().week:02d}"
+
     return {
         "thresholds": {
             "context_relevance": judge_settings.thresholds.context_relevance,
@@ -139,8 +147,8 @@ def build_judge_context(
         },
         "repair_enabled": judge_settings.enabled and judge_settings.max_repairs > 0,
         "max_repairs": judge_settings.max_repairs,
-        # Provide today's date (ISO format) for prompts that need to reference the current day
-        "today": date.today().isoformat(),
+        # Provide today's date (ISO format + weekday + calendar week) for prompts that need to reference the current day
+        "today": today_str,
     }
 
 

--- a/zammad-ai-workflow/config.example.yaml
+++ b/zammad-ai-workflow/config.example.yaml
@@ -222,7 +222,7 @@ triage:
   #
   # Available Jinja2 variables:
   # - Triage prompts: knowledge_base_enabled, dlf_enabled, no_category_name, no_action_name, categories, today
-  # - Answer prompts: available_tools, knowledge_base_enabled, dlf_enabled, disclaimer, today
+  # - Answer prompts: available_tools, knowledge_base_enabled, dlf_enabled, disclaimer, retrieval_num_documents, today
   # - Judge prompts: thresholds (dict), repair_enabled, max_repairs, today
   prompts:
     type: "file" # Options: "langfuse", "string", or "file"

--- a/zammad-ai-workflow/config.example.yaml
+++ b/zammad-ai-workflow/config.example.yaml
@@ -221,9 +221,9 @@ triage:
   # syntax to your existing prompt files.
   #
   # Available Jinja2 variables:
-  # - Triage prompts: knowledge_base_enabled, dlf_enabled, no_category_name, no_action_name, categories
-  # - Answer prompts: available_tools, knowledge_base_enabled, dlf_enabled, disclaimer
-  # - Judge prompts: thresholds (dict), repair_enabled, max_repairs
+  # - Triage prompts: knowledge_base_enabled, dlf_enabled, no_category_name, no_action_name, categories, today
+  # - Answer prompts: available_tools, knowledge_base_enabled, dlf_enabled, disclaimer, today
+  # - Judge prompts: thresholds (dict), repair_enabled, max_repairs, today
   prompts:
     type: "file" # Options: "langfuse", "string", or "file"
     prompt_map:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI workflows now automatically include the current date in prompt context for triage, answer, and judgment, enabling more day-aware responses.

* **Bug Fixes**
  * “Days since request” calculations in triage now use a UTC-based date for more consistent, timezone-independent behavior.

* **Documentation**
  * Updated prompt template configuration docs to list the current set of available Jinja2 variables, including `today` (and judge-specific variables where applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->