### PR TITLE
feat(ticket handling): add pending close scheduling 

### DIFF
--- a/zammad-ai-workflow/app/action/service.py
+++ b/zammad-ai-workflow/app/action/service.py
@@ -79,6 +79,17 @@ class ActionService:
                     internal=False,
                 )
                 self.logger.info(f"Posted answer for ticket {ticket_id} with category {category}")
+                # Optionally schedule the ticket to be moved to a pending-close state after configured days
+                try:
+                    pending_days: int | None = self.settings.zammad.pending_close_after_days
+                    if pending_days is not None:
+                        await self.zammad_client.set_ticket_pending_close(ticket_id=ticket_id, days=pending_days)
+                        self.logger.info(
+                            f"Scheduled ticket {ticket_id} to be set to pending close after {pending_days} days"
+                        )
+                except Exception:
+                    # Don't fail the action execution if scheduling fails — just log
+                    self.logger.error("Failed to schedule pending-close update for ticket.", exc_info=True)
             else:
                 await self.zammad_client.post_shared_draft(
                     ticket_id=ticket_id,

--- a/zammad-ai-workflow/app/settings/zammad.py
+++ b/zammad-ai-workflow/app/settings/zammad.py
@@ -165,6 +165,11 @@ class BaseZammadSettings(BaseModel, ABC):
         description="Optional proxy URL for routing HTTP requests to Zammad through a proxy server.",
         default=None,
     )
+    # If set, the integration will schedule a ticket state update after the configured number of days
+    pending_close_after_days: PositiveInt | None = Field(
+        description="If set, AI auto-published answers will schedule a ticket status update after this many days.",
+        default=None,
+    )
     document_parsing: DocumentParsingSettings = Field(
         description="Settings for parsing documents retrieved from Zammad.",
         default_factory=DocumentParsingSettings,

--- a/zammad-ai-workflow/app/triage/triage.py
+++ b/zammad-ai-workflow/app/triage/triage.py
@@ -1,6 +1,6 @@
 """Core triage service for ticket categorization and action selection."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 from time import perf_counter
 
 from dotenv import load_dotenv
@@ -394,7 +394,7 @@ class TriageService:
                                     days_result: DaysSinceRequestResponse = (
                                         await self.genai_handler.extract_days_since_request(
                                             message=message,
-                                            today=datetime.now(timezone.utc).date().isoformat(),
+                                            today=datetime.now().date().isoformat(),
                                             session_id=session_id,
                                         )
                                     )

--- a/zammad-ai-workflow/app/zammad/api.py
+++ b/zammad-ai-workflow/app/zammad/api.py
@@ -70,7 +70,7 @@ class ZammadAPIClient(BaseZammadClient):
 
     @override
     async def set_ticket_pending_close(self, ticket_id: int, days: int) -> None:
-        pending_date = (datetime.now() + timedelta(days=days)).isoformat() + "Z"
+        pending_date = (datetime.now() + timedelta(days=days)).isoformat()
         payload = {"id": ticket_id, "state": "pending close", "pending_time": pending_date}
         await self._request("PUT", f"/api/v1/tickets/{ticket_id}", json=payload)
         logger.info(f"Updated ticket {ticket_id} to pending close after {days} days")

--- a/zammad-ai-workflow/app/zammad/api.py
+++ b/zammad-ai-workflow/app/zammad/api.py
@@ -2,6 +2,7 @@
 
 from base64 import b64decode
 from binascii import Error as BinasciiError
+from datetime import datetime, timedelta
 from logging import Logger
 from typing import Any, override
 
@@ -66,6 +67,13 @@ class ZammadAPIClient(BaseZammadClient):
         payload = {"group_id": group_id, "id": ticket_id}
         await self._request("PUT", f"/api/v1/tickets/{ticket_id}", json=payload)
         logger.info(f"Updated ticket {ticket_id} group to {group_id}")
+
+    @override
+    async def set_ticket_pending_close(self, ticket_id: int, days: int) -> None:
+        pending_date = (datetime.now() + timedelta(days=days)).isoformat() + "Z"
+        payload = {"id": ticket_id, "state": "pending close", "pending_time": pending_date}
+        await self._request("PUT", f"/api/v1/tickets/{ticket_id}", json=payload)
+        logger.info(f"Updated ticket {ticket_id} to pending close after {days} days")
 
     @override
     async def post_shared_draft(self, ticket_id: int, text: str) -> None:

--- a/zammad-ai-workflow/app/zammad/base.py
+++ b/zammad-ai-workflow/app/zammad/base.py
@@ -56,6 +56,16 @@ class BaseZammadClient(ABC):
         ...
 
     @abstractmethod
+    async def set_ticket_pending_close(self, ticket_id: int, days: int) -> None:
+        """Update the ticket state to "pending close".
+
+        Args:
+            ticket_id: ID of the ticket to update.
+            days: Number of days after which the ticket should be marked as pending close.
+        """
+        ...
+
+    @abstractmethod
     async def post_answer(
         self,
         ticket_id: int,

--- a/zammad-ai-workflow/app/zammad/eai.py
+++ b/zammad-ai-workflow/app/zammad/eai.py
@@ -126,6 +126,13 @@ class ZammadEAIClient(BaseZammadClient):
         logger.info(f"Updated ticket {ticket_id} group to {group_id}")
 
     @override
+    async def set_ticket_pending_close(self, ticket_id: int, days: int) -> None:
+        pending_date = (datetime.now() + timedelta(days=days)).isoformat() + "Z"
+        payload = {"id": ticket_id, "state": "pending close", "pending_time": pending_date}
+        await self._request("PATCH", f"/tickets/{ticket_id}", json=payload)
+        logger.info(f"Updated ticket {ticket_id} to pending close after {days} days")
+
+    @override
     async def post_answer(self, ticket_id: int, text: str, subject: str | None = None, internal: bool = False) -> None:
         payload = ZammadAnswer(ticket_id=ticket_id, body=text, internal=internal, subject=subject)
         await self._request("POST", f"/tickets/{ticket_id}/articles", json=payload.model_dump())

--- a/zammad-ai-workflow/app/zammad/eai.py
+++ b/zammad-ai-workflow/app/zammad/eai.py
@@ -127,7 +127,7 @@ class ZammadEAIClient(BaseZammadClient):
 
     @override
     async def set_ticket_pending_close(self, ticket_id: int, days: int) -> None:
-        pending_date = (datetime.now() + timedelta(days=days)).isoformat() + "Z"
+        pending_date = (datetime.now() + timedelta(days=days)).isoformat()
         payload = {"id": ticket_id, "state": "pending close", "pending_time": pending_date}
         await self._request("PATCH", f"/tickets/{ticket_id}", json=payload)
         logger.info(f"Updated ticket {ticket_id} to pending close after {days} days")

--- a/zammad-ai-workflow/config.example.yaml
+++ b/zammad-ai-workflow/config.example.yaml
@@ -56,6 +56,7 @@ genai:
 
 zammad:
   type: "api" # Options: "api" or "eai"
+  pending_close_after_days: null # Number of days after which a ticket is marked as pending close. Only for "auto-publish" categories
 
   # For type: "api"
   base_url: "https://your-zammad-instance.example.com"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `pending_close_after_days` setting to automatically move tickets to **pending close** after an **auto-published** reply, using Zammad’s pending-close state.
  * Updated the example configuration to include the new option.

* **Bug Fixes / Improvements**
  * Scheduling the pending-close update is best-effort: failures are logged without affecting the main reply flow.
  * Improved “days since request” calculation by anchoring it to local time instead of UTC.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->