### PR TITLE
feat(agent): make recursion limit configurable

### DIFF
--- a/zammad-ai-workflow/app/settings/settings.py
+++ b/zammad-ai-workflow/app/settings/settings.py
@@ -119,6 +119,11 @@ class ZammadAISettings(BaseSettings):
         default=2000,
     )
 
+    recursion_limit: PositiveInt = Field(
+        description="Maximum recursion depth limit for the agents to prevent the agent from running infinite tool call loops.",
+        default=30,
+    )
+
     api: APISettings = Field(
         description="Settings for the REST API, including authentication and rate limiting configuration.",
         default_factory=lambda: APISettings(),

--- a/zammad-ai-workflow/app/utils/langchain.py
+++ b/zammad-ai-workflow/app/utils/langchain.py
@@ -7,14 +7,15 @@ from langchain.messages import HumanMessage
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, ValidationError
 
+from app.settings import ZammadAISettings, get_settings
+
 T = TypeVar("T")
 
-DEFAULT_RECURSION_LIMIT = 10
-
-
-def with_recursion_limit(config: RunnableConfig, limit: int = DEFAULT_RECURSION_LIMIT) -> RunnableConfig:
+def with_recursion_limit(config: RunnableConfig, settings: ZammadAISettings | None = None) -> RunnableConfig:
     """Return a RunnableConfig with a bounded LangGraph recursion limit."""
-    return RunnableConfig({**config, "recursion_limit": limit})
+    if settings is None:
+        settings = get_settings()
+    return RunnableConfig({**config, "recursion_limit": settings.recursion_limit})
 
 
 def extract_structured_response(

--- a/zammad-ai-workflow/config.example.yaml
+++ b/zammad-ai-workflow/config.example.yaml
@@ -129,7 +129,7 @@ answer:
   laws: []
     # Optional: expose indexed laws as separate agent tools.
     # - id: "fev"
-    #   name: "Fahrerlaubnis-Verordnung"
+    #  name: "Fahrerlaubnis-Verordnung"
   dlf:
     url: "https://your-dlf-backend.example.com/api"
     filter_categories: [] # Optional: list of categories to filter DLF results, or null for no filtering
@@ -188,6 +188,9 @@ kafka:
 
 # Maximum combined article and attachment text length accepted for triage/answer processing.
 max_user_text_length: 2000
+
+# Maximum recursion depth for agents to prevent infinite tool calling loops.
+# recursion_limit: 30
 
 # ============================================================================
 # Triage Configuration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable recursion limit for AI workflow tool-calling, defaulting to 30.
  * Recursion limits can now be managed through application settings.

* **Documentation**
  * Updated the example configuration to document the optional global recursion limit.
  * Corrected indentation in the example laws configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->