### PR TITLE
feat(indexer): store law url in each law point

### DIFF
--- a/zammad-ai-index/README.md
+++ b/zammad-ai-index/README.md
@@ -109,7 +109,8 @@ uv run python main.py
 
 Notes:
 
-- Documents are chunked and written with metadata including `source=law`, `law_id`, `document_type`, `law_name`, `paragraph`, `chunk`, and a `pagecontent_hash`.
+- Documents are chunked and written with metadata including `source=law`, `law_id`, `document_type`, `law_name`, `paragraph`, `chunk`, `pagecontent_hash`, and `law_url` (the configured source URL).
+- The `law_url` metadata stores the canonical URL that was used to fetch the law; this helps traceability and auditing of indexed legal text.
 - Deterministic IDs are generated per paragraph chunk to upsert documents on subsequent runs.
 - A snapshot is created before writing; snapshot failure aborts the run.
 - `document_type` is either law or annex.

--- a/zammad-ai-index/job/law/ingest.py
+++ b/zammad-ai-index/job/law/ingest.py
@@ -225,10 +225,14 @@ def ingest_law(law: LawConfig, qdrant: QdrantKBClient) -> None:
         docs_annex = _chunk_annexes(annexes, law.chunk_size, law.chunk_overlap) if annexes else []
         docs = [*docs_para, *docs_annex]
 
-        # enrich with law-level metadata
+        # enrich with law-level metadata (include the configured source URL)
         for d in docs:
             d.metadata["law_id"] = law.id
             d.metadata["law_name"] = law.name
+            # Preserve the canonical URL from which this law was fetched so
+            # downstream consumers (or audits) can trace back the original
+            # source. Stored as a string to keep metadata JSON-serializable.
+            d.metadata["law_url"] = str(law.url)
 
         if not docs:
             logger.info("No chunks generated for law %s, nothing to index.", law.id)

--- a/zammad-ai-workflow/app/answer/knowledgebase.py
+++ b/zammad-ai-workflow/app/answer/knowledgebase.py
@@ -217,6 +217,19 @@ class QdrantKBClient:
         """
         if k is None:
             k = self.qdrant_settings.retrieval_num_documents
+
+        # By default, restrict general knowledge-base searches to points that
+        # are NOT law-indexed. Laws are stored in the same collection and are
+        # identified by the presence of the metadata key `law_id`. When no
+        # explicit search_filter is provided, add a filter that requires
+        # metadata.law_id to be null (i.e., the key does not exist), so law
+        # chunks are excluded from general KB searches and remain accessible
+        # only via dedicated law tools.
+        if search_filter is None:
+            search_filter = Filter(
+                must=[FieldCondition(key="metadata.law_id", is_null=True)]
+            )
+
         return await self.vectorstore.asimilarity_search_with_relevance_scores(
             query=query,
             k=k,

--- a/zammad-ai-workflow/test/test_answer_laws.py
+++ b/zammad-ai-workflow/test/test_answer_laws.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
+from langchain_core.documents import Document
 
 from app.answer.knowledgebase import QdrantKBClient
 from app.answer.laws import build_law_tool_name
@@ -64,3 +65,81 @@ async def test_asearch_law_documents_filters_by_law_metadata() -> None:
     search_filter = captured_kwargs["filter"]
     assert [condition.key for condition in search_filter.must] == ["metadata.source", "metadata.law_id"]
     assert [condition.match.value for condition in search_filter.must] == ["law", "fev"]
+
+
+@pytest.mark.asyncio
+async def test_asearch_documents_excludes_law_points_by_default() -> None:
+    """General KB retrieval should exclude law-indexed points by default (law_id absent).
+
+    The default filter should require metadata.law_id to be null (i.e. the key
+    does not exist) so that law chunks are not returned by general KB searches.
+    """
+    client = QdrantKBClient.__new__(QdrantKBClient)
+    client.qdrant_settings = type("Settings", (), {"retrieval_num_documents": 5})()
+    client.vectorstore = FakeVectorStore()
+
+    result = await client.asearch_documents(query="Test", k=4, offset=1)
+
+    assert result == []
+    captured_kwargs = client.vectorstore.kwargs
+    assert captured_kwargs is not None
+    assert captured_kwargs["query"] == "Test"
+    assert captured_kwargs["k"] == 4
+    assert captured_kwargs["offset"] == 1
+    search_filter = captured_kwargs["filter"]
+    # Expect a must clause checking metadata.law_id is null
+    assert [condition.key for condition in search_filter.must] == ["metadata.law_id"]
+    # The FieldCondition for existence uses is_null=True for missing keys
+    assert getattr(search_filter.must[0], "is_null", None) is True
+
+
+@pytest.mark.asyncio
+async def test_asearch_documents_respects_explicit_filter() -> None:
+    """If an explicit filter is provided, it should be used instead of the default."""
+    client = QdrantKBClient.__new__(QdrantKBClient)
+    client.qdrant_settings = type("Settings", (), {"retrieval_num_documents": 5})()
+    client.vectorstore = FakeVectorStore()
+
+    # Build a simple explicit filter object (we don't need real qdrant types here)
+    explicit_filter = object()
+
+    result = await client.asearch_documents(query="Test2", k=2, offset=0, search_filter=explicit_filter)
+
+    assert result == []
+    captured_kwargs = client.vectorstore.kwargs
+    assert captured_kwargs is not None
+    assert captured_kwargs["filter"] is explicit_filter
+
+
+@pytest.mark.asyncio
+async def test_asearch_documents_returns_only_kb_article_from_vectorstore() -> None:
+    """When the underlying vectorstore contains both a KB article and a law chunk, asearch_documents (with its default filter) should return only the KB article."""
+    class FakeVectorStoreWithDocs:
+        def __init__(self) -> None:
+            self.kb_doc = Document(page_content="KB: How to reset password", metadata={"title": "Reset password"})
+            self.law_doc = Document(page_content="LAW: §11 Eignung", metadata={"law_id": "fev", "source": "law"})
+
+        async def asimilarity_search_with_relevance_scores(self, **kwargs: Any) -> list:
+            # Inspect provided filter to decide which documents to return.
+            f = kwargs.get("filter")
+            # If the filter explicitly requires metadata.law_id to be null,
+            # emulate Qdrant by returning only the KB document.
+            must = getattr(f, "must", None)
+            if must:
+                for cond in must:
+                    if getattr(cond, "key", None) == "metadata.law_id" and getattr(cond, "is_null", None) is True:
+                        return [(self.kb_doc, 0.9)]
+            # Otherwise return both documents
+            return [(self.kb_doc, 0.9), (self.law_doc, 0.5)]
+
+    client = QdrantKBClient.__new__(QdrantKBClient)
+    client.qdrant_settings = type("Settings", (), {"retrieval_num_documents": 5})()
+    client.vectorstore = FakeVectorStoreWithDocs()
+
+    result = await client.asearch_documents(query="reset", k=5, offset=0)
+
+    # Expect only the KB article to be returned
+    assert isinstance(result, list)
+    assert len(result) == 1
+    doc, score = result[0]
+    assert "KB:" in doc.page_content


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Law-indexed documents now include the configured source URL in their metadata for traceability and auditing.

* **Documentation**
  * Updated law-ingestion documentation to describe the new source URL metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->