### PR TITLE
refactor(guardrail): update guardrail evaluation to accept unsafe 

### DIFF
--- a/zammad-ai-workflow/app/action/service.py
+++ b/zammad-ai-workflow/app/action/service.py
@@ -6,7 +6,6 @@ from app.answer.service import AnswerService, get_answer_service
 from app.errors import ActionExecutionError, AppError
 from app.guardrails import GuardrailService, reset_guardrail_service
 from app.models.answer import AnswerCandidate, NoAnswerPossible, StaticAnswer
-from app.models.guardrails import GuardrailResponseResult, GuardrailResult
 from app.models.triage import Action
 from app.settings.settings import ZammadAISettings
 from app.settings.triage import ActionTypes
@@ -154,7 +153,7 @@ class ActionService:
             ActionExecutionError: If guardrails fail with block_on_high_risk enabled, or if no action is found.
         """
         # Evaluate guardrails before answer generation
-        guardrail_result: GuardrailResult | None = await self.guardrail_service.evaluate(
+        guardrail_result: bool = await self.guardrail_service.evaluate(
             user_text,
             toxicity_labels=[
                 "violence_and_weapons",
@@ -172,13 +171,9 @@ class ActionService:
             ],
             jailbreak_labels=None,
         )
-        if self.settings.guardrails.enabled:
-            self.logger.info(
-                f"Guardrail check in get_answer for ticket {ticket_id if ticket_id is not None else 'unknown'}: safety={guardrail_result.prompt_safety if guardrail_result else 'unknown'}, toxicity={guardrail_result.prompt_toxicity if guardrail_result else 'unknown'}, jailbreak={guardrail_result.jailbreak_detection if guardrail_result else 'unknown'}"
-            )
 
         if (
-            (not guardrail_result or not guardrail_result.prompt_safety == "safe")
+            not guardrail_result
             and self.guardrail_service.settings.block_on_high_risk
             and self.guardrail_service.settings.enabled
         ):
@@ -234,12 +229,12 @@ class ActionService:
 
         # Evaluate guardrails on the generated response as well
         if isinstance(response, AnswerCandidate):
-            response_guardrail_result: GuardrailResponseResult | None = await self.guardrail_service.evaluate_response(
+            response_guardrail_result: bool = await self.guardrail_service.evaluate_response(
                 text=user_text, response=response.response
             )
             self.logger.debug(f"Guardrail evaluation for response: {response_guardrail_result}")
             if (
-                (not response_guardrail_result or not response_guardrail_result.response_safety == "safe")
+                not response_guardrail_result
                 and self.guardrail_service.settings.block_on_high_risk
                 and self.guardrail_service.settings.enabled
             ):

--- a/zammad-ai-workflow/app/action/service.py
+++ b/zammad-ai-workflow/app/action/service.py
@@ -3,7 +3,7 @@
 from logging import Logger
 
 from app.answer.service import AnswerService, get_answer_service
-from app.errors import ActionExecutionError, AppError
+from app.errors import ActionExecutionError, AppError, GuardrailEvaluationError
 from app.guardrails import GuardrailService, reset_guardrail_service
 from app.models.answer import AnswerCandidate, NoAnswerPossible, StaticAnswer
 from app.models.triage import Action
@@ -153,42 +153,34 @@ class ActionService:
             ActionExecutionError: If guardrails fail with block_on_high_risk enabled, or if no action is found.
         """
         # Evaluate guardrails before answer generation
-        guardrail_result: bool = await self.guardrail_service.evaluate(
-            user_text,
-            toxicity_labels=[
-                "violence_and_weapons",
-                "sexual_content",
-                "hate_and_discrimination",
-                "self_harm_and_suicide",
-                "misinformation",
-                "copyright_violation",
-                "child_safety",
-                "political_manipulation",
-                "unethical_conduct",
-                "regulated_advice",
-                "other",
-                "benign",
-            ],
-            jailbreak_labels=None,
-        )
+        try:
+            guardrail_result: bool = await self.guardrail_service.evaluate(
+                user_text,
+                toxicity_labels=[
+                    "violence_and_weapons",
+                    "sexual_content",
+                    "hate_and_discrimination",
+                    "self_harm_and_suicide",
+                    "misinformation",
+                    "copyright_violation",
+                    "child_safety",
+                    "political_manipulation",
+                    "unethical_conduct",
+                    "regulated_advice",
+                    "other",
+                    "benign",
+                ],
+                jailbreak_labels=None,
+            )
+        except GuardrailEvaluationError as e:
+            self.logger.error("Guardrail evaluation failed before answer generation.", exc_info=True)
+            raise ActionExecutionError("Guardrail evaluation failed before answer generation", retryable=True) from e
 
-        if (
-            not guardrail_result
-            and self.guardrail_service.settings.block_on_high_risk
-            and self.guardrail_service.settings.enabled
-        ):
+        if self.guardrail_service.settings.enabled and self.guardrail_service.settings.block_on_high_risk and not guardrail_result:
             self.logger.warning(
                 f"Answer generation blocked by guardrails for ticket {ticket_id if ticket_id is not None else 'unknown'}"
             )
-            if not guardrail_result:
-                raise ActionExecutionError(
-                    "Guardrail evaluation failed or returned no result; action execution blocked",
-                    retryable=True,
-                )
-            raise ActionExecutionError(
-                f"Input failed safety checks: {guardrail_result.prompt_toxicity}, {guardrail_result.jailbreak_detection}",
-                retryable=False,
-            )
+            raise ActionExecutionError("Input failed safety checks", retryable=False)
 
         if len(user_text) > self.settings.max_user_text_length:
             self.logger.warning(
@@ -229,27 +221,21 @@ class ActionService:
 
         # Evaluate guardrails on the generated response as well
         if isinstance(response, AnswerCandidate):
-            response_guardrail_result: bool = await self.guardrail_service.evaluate_response(
-                text=user_text, response=response.response
-            )
+            try:
+                response_guardrail_result: bool = await self.guardrail_service.evaluate_response(
+                    text=user_text, response=response.response
+                )
+            except GuardrailEvaluationError as e:
+                self.logger.error("Guardrail evaluation failed for generated response.", exc_info=True)
+                raise ActionExecutionError(
+                    "Guardrail evaluation failed for generated response", retryable=True
+                ) from e
             self.logger.debug(f"Guardrail evaluation for response: {response_guardrail_result}")
-            if (
-                not response_guardrail_result
-                and self.guardrail_service.settings.block_on_high_risk
-                and self.guardrail_service.settings.enabled
-            ):
+            if self.guardrail_service.settings.enabled and self.guardrail_service.settings.block_on_high_risk and not response_guardrail_result:
                 self.logger.warning(
                     f"Generated response blocked by guardrails for ticket {ticket_id if ticket_id is not None else 'unknown'}"
                 )
-                if not response_guardrail_result:
-                    raise ActionExecutionError(
-                        "Guardrail evaluation for generated response failed or returned no result; action execution blocked",
-                        retryable=True,
-                    )
-                raise ActionExecutionError(
-                    f"Generated response failed safety checks: {response_guardrail_result.response_toxicity}, {response_guardrail_result.response_refusal}",
-                    retryable=False,
-                )
+                raise ActionExecutionError("Generated response failed safety checks", retryable=False)
 
         return response
 

--- a/zammad-ai-workflow/app/answer/dlf.py
+++ b/zammad-ai-workflow/app/answer/dlf.py
@@ -6,7 +6,7 @@ from httpx import AsyncClient, ConnectError, HTTPStatusError, ReadTimeout, Respo
 from pydantic import BaseModel, Field
 from stamina import retry_context
 
-from app.errors import DLFPermanentError, DLFRetryableError
+from app.errors import DLFPermanentError, DLFRetryableError, GuardrailEvaluationError
 from app.guardrails.http_client import GuardrailService
 from app.settings.answer import DLFSettings
 from app.utils.logging import getLogger
@@ -104,17 +104,22 @@ class DLFClient:
             DLFError: If there is an error during retrieval, such as network issues or invalid responses from the DLF API.
         """
         # Check query for PII and safety using guardrails
-        guardrail_result: bool = await self.guardrail_service.evaluate(
-            query,
-            toxicity_labels=[
-                "pii_exposure",
-                "privacy_violation",
-                "non_violent_crime",
-                "benign",
-            ],
-            jailbreak_labels=None,
-        )
-        if not guardrail_result:
+        try:
+            guardrail_result: bool = await self.guardrail_service.evaluate(
+                query,
+                toxicity_labels=[
+                    "pii_exposure",
+                    "privacy_violation",
+                    "non_violent_crime",
+                    "benign",
+                ],
+                jailbreak_labels=None,
+            )
+        except GuardrailEvaluationError as e:
+            self.logger.error("Failed to evaluate DLF query guardrails.", exc_info=True)
+            raise DLFRetryableError("Failed to evaluate DLF query guardrails.") from e
+
+        if self.guardrail_service.settings.enabled and not guardrail_result:
             self.logger.warning(
                 msg="Query flagged as unsafe by guardrails.",
             )

--- a/zammad-ai-workflow/app/answer/dlf.py
+++ b/zammad-ai-workflow/app/answer/dlf.py
@@ -8,7 +8,6 @@ from stamina import retry_context
 
 from app.errors import DLFPermanentError, DLFRetryableError
 from app.guardrails.http_client import GuardrailService
-from app.models.guardrails import GuardrailResult
 from app.settings.answer import DLFSettings
 from app.utils.logging import getLogger
 
@@ -105,7 +104,7 @@ class DLFClient:
             DLFError: If there is an error during retrieval, such as network issues or invalid responses from the DLF API.
         """
         # Check query for PII and safety using guardrails
-        guardrail_result: GuardrailResult | None = await self.guardrail_service.evaluate(
+        guardrail_result: bool = await self.guardrail_service.evaluate(
             query,
             toxicity_labels=[
                 "pii_exposure",
@@ -115,23 +114,11 @@ class DLFClient:
             ],
             jailbreak_labels=None,
         )
-        if guardrail_result is not None:
-            if guardrail_result.prompt_safety == "unsafe":
-                self.logger.warning(
-                    msg="Query flagged as unsafe by guardrails.",
-                    extra={"guardrail_result": guardrail_result.model_dump()},
-                )
-                raise DLFError("Query flagged as unsafe by guardrails.")
-            if (
-                "pii_exposure" in guardrail_result.prompt_toxicity
-                or "privacy_violation" in guardrail_result.prompt_toxicity
-                or "non_violent_crime" in guardrail_result.prompt_toxicity
-            ):
-                self.logger.warning(
-                    msg="Query flagged for potential PII exposure by guardrails.",
-                    extra={"guardrail_result": guardrail_result.model_dump()},
-                )
-                raise DLFError("Query flagged for potential PII exposure by guardrails.")
+        if not guardrail_result:
+            self.logger.warning(
+                msg="Query flagged as unsafe by guardrails.",
+            )
+            raise DLFError("Query flagged as unsafe by guardrails.")
 
         # Create payload
         payload = DLFAPIPayload(

--- a/zammad-ai-workflow/app/errors.py
+++ b/zammad-ai-workflow/app/errors.py
@@ -4,11 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from logging import Logger
-
-from app.utils.logging import getLogger
-
-logger: Logger = getLogger("zammad-ai.errors")
 
 
 @dataclass(slots=True, frozen=True)
@@ -82,6 +77,16 @@ class DLFPermanentError(DLFError):
     """Permanent DLF failure that should be dropped."""
 
     retryable = False
+
+
+class GuardrailError(AppError):
+    """Base exception for guardrail evaluation errors."""
+
+
+class GuardrailEvaluationError(GuardrailError):
+    """Transient or malformed guardrail evaluation failure."""
+
+    retryable = True
 
 
 class QdrantError(AppError):

--- a/zammad-ai-workflow/app/guardrails/http_client.py
+++ b/zammad-ai-workflow/app/guardrails/http_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Final
 
 import httpx
@@ -9,9 +10,9 @@ from dotenv import load_dotenv
 from httpx._models import Response
 from truststore import inject_into_ssl
 
+from app.errors import GuardrailEvaluationError
 from app.models.guardrails import GuardrailResponseResult, GuardrailResult
 from app.settings.guardrails import GuardrailSettings
-from app.utils.logging import getLogger
 
 load_dotenv()
 inject_into_ssl()
@@ -51,7 +52,7 @@ class GuardrailService:
     ) -> bool:
         """Evaluate user input text via remote guardrail service or skip when disabled."""
         if not self.settings.enabled:
-            return False
+            return True
 
         # Skip empty text to avoid unnecessary calls
         if not text or not text.strip():
@@ -73,10 +74,10 @@ class GuardrailService:
             # Coerce using our Pydantic model to guard against schema drift
             result = GuardrailResult(**data)
             return is_guardrail_safe(result)
-        except Exception:
+        except Exception as e:
             # Fail-open on any error
             logger.error("Remote guardrail evaluate failed.", exc_info=True)
-            return False
+            raise GuardrailEvaluationError("Remote guardrail evaluate failed") from e
 
     async def close(self) -> None:
         """Close the underlying HTTPX client."""
@@ -89,7 +90,7 @@ class GuardrailService:
     async def evaluate_response(self, text: str, response: str, toxicity_labels: list[str] | None = None) -> bool:
         """Evaluate generated response via remote guardrail service or skip when disabled."""
         if not self.settings.enabled:
-            return False
+            return True
 
         if not response or not response.strip():
             logger.debug("Guardrail skipped for empty response")
@@ -108,9 +109,9 @@ class GuardrailService:
             resp.raise_for_status()
             data: Any = resp.json()
             return is_guardrail_safe(GuardrailResponseResult(**data))
-        except Exception:
+        except Exception as e:
             logger.error("Remote guardrail evaluate_response failed.", exc_info=True)
-            return False
+            raise GuardrailEvaluationError("Remote guardrail evaluate_response failed") from e
 
 
 _service: GuardrailService | None = None

--- a/zammad-ai-workflow/app/guardrails/http_client.py
+++ b/zammad-ai-workflow/app/guardrails/http_client.py
@@ -48,15 +48,15 @@ class GuardrailService:
 
     async def evaluate(
         self, text: str, toxicity_labels: list[str] | None = None, jailbreak_labels: list[str] | None = None
-    ) -> GuardrailResult | None:
+    ) -> bool:
         """Evaluate user input text via remote guardrail service or skip when disabled."""
         if not self.settings.enabled:
-            return None
+            return False
 
         # Skip empty text to avoid unnecessary calls
         if not text or not text.strip():
             logger.debug("Guardrail skipped for empty text")
-            return SAFE_PROMPT_RESULT
+            return True
 
         url = f"{self._base_url}/api/v1/guardrails/prompt"
         payload = {
@@ -71,11 +71,12 @@ class GuardrailService:
             resp.raise_for_status()
             data: Any = resp.json()
             # Coerce using our Pydantic model to guard against schema drift
-            return GuardrailResult(**data)
+            result = GuardrailResult(**data)
+            return is_guardrail_safe(result)
         except Exception:
             # Fail-open on any error
             logger.error("Remote guardrail evaluate failed.", exc_info=True)
-            return None
+            return False
 
     async def close(self) -> None:
         """Close the underlying HTTPX client."""
@@ -85,16 +86,14 @@ class GuardrailService:
         await self._client.aclose()
         self._closed = True
 
-    async def evaluate_response(
-        self, text: str, response: str, toxicity_labels: list[str] | None = None
-    ) -> GuardrailResponseResult | None:
+    async def evaluate_response(self, text: str, response: str, toxicity_labels: list[str] | None = None) -> bool:
         """Evaluate generated response via remote guardrail service or skip when disabled."""
         if not self.settings.enabled:
-            return None
+            return False
 
         if not response or not response.strip():
             logger.debug("Guardrail skipped for empty response")
-            return SAFE_RESPONSE_RESULT
+            return True
 
         url = f"{self._base_url}/api/v1/guardrails/response"
         payload = {
@@ -108,10 +107,10 @@ class GuardrailService:
             resp: Response = await self._client.post(url, json=payload)
             resp.raise_for_status()
             data: Any = resp.json()
-            return GuardrailResponseResult(**data)
+            return is_guardrail_safe(GuardrailResponseResult(**data))
         except Exception:
             logger.error("Remote guardrail evaluate_response failed.", exc_info=True)
-            return None
+            return False
 
 
 _service: GuardrailService | None = None
@@ -133,3 +132,22 @@ def reset_guardrail_service() -> None:
     """Clear the shared GuardrailService singleton so it can be recreated."""
     global _service
     _service = None
+
+
+def is_guardrail_safe(guardrail_result: GuardrailResult | GuardrailResponseResult | None) -> bool:
+    """Determine if the guardrail result is safe or not."""
+    if guardrail_result is None:
+        return False
+    elif isinstance(guardrail_result, GuardrailResult):
+        if guardrail_result.prompt_safety == "safe":
+            return True
+        if (
+            len(guardrail_result.jailbreak_detection) == 1 and guardrail_result.jailbreak_detection[0] == "benign"
+        ) and (len(guardrail_result.prompt_toxicity) == 1 and guardrail_result.prompt_toxicity[0] == "benign"):
+            return True
+    elif isinstance(guardrail_result, GuardrailResponseResult):
+        if guardrail_result.response_safety == "safe":
+            return True
+        if len(guardrail_result.response_toxicity) == 1 and guardrail_result.response_toxicity[0] == "benign":
+            return True
+    return False

--- a/zammad-ai-workflow/app/triage/triage.py
+++ b/zammad-ai-workflow/app/triage/triage.py
@@ -10,6 +10,7 @@ from truststore import inject_into_ssl
 
 from app.errors import (
     GenAIError,
+    GuardrailEvaluationError,
     TriageCategoryWrongError,
     ZammadRetryableError,
 )
@@ -319,39 +320,32 @@ class TriageService:
             )
 
         # Evaluate guardrails before categorization
-        guardrail_result: bool = await self.guardrail_service.evaluate(
-            message,
-            toxicity_labels=[
-                "violence_and_weapons",
-                "sexual_content",
-                "hate_and_discrimination",
-                "self_harm_and_suicide",
-                "misinformation",
-                "copyright_violation",
-                "child_safety",
-                "political_manipulation",
-                "unethical_conduct",
-                "regulated_advice",
-                "other",
-                "benign",
-            ],
-            jailbreak_labels=None,
-        )
-        if (
-            not guardrail_result
-            and self.guardrail_service.settings.block_on_high_risk
-            and self.guardrail_service.settings.enabled
-        ):
-            logger.warning("Categorization blocked by guardrails")
-            if not guardrail_result:
-                raise TriageError(
-                    "Guardrail evaluation failed or returned no result; categorization blocked",
-                    retryable=True,
-                )
-            raise TriageError(
-                f"Input failed safety checks: {guardrail_result.prompt_toxicity}, {guardrail_result.jailbreak_detection}",
-                retryable=False,
+        try:
+            guardrail_result: bool = await self.guardrail_service.evaluate(
+                message,
+                toxicity_labels=[
+                    "violence_and_weapons",
+                    "sexual_content",
+                    "hate_and_discrimination",
+                    "self_harm_and_suicide",
+                    "misinformation",
+                    "copyright_violation",
+                    "child_safety",
+                    "political_manipulation",
+                    "unethical_conduct",
+                    "regulated_advice",
+                    "other",
+                    "benign",
+                ],
+                jailbreak_labels=None,
             )
+        except GuardrailEvaluationError as e:
+            logger.error("Guardrail evaluation failed before categorization.", exc_info=True)
+            raise TriageError("Guardrail evaluation failed before categorization", retryable=True) from e
+
+        if self.guardrail_service.settings.enabled and self.guardrail_service.settings.block_on_high_risk and not guardrail_result:
+            logger.warning("Categorization blocked by guardrails")
+            raise TriageError("Input failed safety checks", retryable=False)
 
         if len(message) > self.max_user_text_length:
             logger.warning(

--- a/zammad-ai-workflow/app/triage/triage.py
+++ b/zammad-ai-workflow/app/triage/triage.py
@@ -17,7 +17,6 @@ from app.errors import (
     TriageError as AppTriageError,
 )
 from app.guardrails import GuardrailService, get_guardrail_service, reset_guardrail_service
-from app.models.guardrails import GuardrailResult
 from app.models.triage import (
     CategorizationResult,
     DaysSinceRequestResponse,
@@ -320,7 +319,7 @@ class TriageService:
             )
 
         # Evaluate guardrails before categorization
-        guardrail_result: GuardrailResult | None = await self.guardrail_service.evaluate(
+        guardrail_result: bool = await self.guardrail_service.evaluate(
             message,
             toxicity_labels=[
                 "violence_and_weapons",
@@ -338,13 +337,8 @@ class TriageService:
             ],
             jailbreak_labels=None,
         )
-        if self.settings.guardrails.enabled:
-            logger.info(
-                f"Guardrail check in predict_category: safety={guardrail_result.prompt_safety if guardrail_result else 'unknown'}, toxicity={guardrail_result.prompt_toxicity if guardrail_result else 'unknown'}, jailbreak={guardrail_result.jailbreak_detection if guardrail_result else 'unknown'}"
-            )
-
         if (
-            (not guardrail_result or not guardrail_result.prompt_safety == "safe")
+            not guardrail_result
             and self.guardrail_service.settings.block_on_high_risk
             and self.guardrail_service.settings.enabled
         ):

--- a/zammad-ai-workflow/test/test_action_guardrails.py
+++ b/zammad-ai-workflow/test/test_action_guardrails.py
@@ -1,0 +1,177 @@
+"""Tests for guardrail mapping inside the action service."""
+
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.action.service as action_module
+from app.errors import ActionExecutionError, GuardrailEvaluationError
+from app.guardrails import GuardrailService
+from app.models.answer import AnswerCandidate
+from app.models.triage import Action
+from app.settings.guardrails import GuardrailSettings
+from app.settings.triage import ActionTypes
+
+
+class _DummyZammadClient:
+    def __init__(self, settings) -> None:
+        self.settings = settings
+
+    async def close(self) -> None:
+        return None
+
+    async def post_answer(self, *args, **kwargs) -> None:
+        raise AssertionError("post_answer should not be called")
+
+    async def post_shared_draft(self, *args, **kwargs) -> None:
+        raise AssertionError("post_shared_draft should not be called")
+
+    async def set_ticket_pending_close(self, *args, **kwargs) -> None:
+        raise AssertionError("set_ticket_pending_close should not be called")
+
+
+class _GuardrailStub:
+    def __init__(
+        self,
+        settings: GuardrailSettings,
+        *,
+        evaluate_result: bool = True,
+        evaluate_response_result: bool = True,
+        evaluate_exc: Exception | None = None,
+        evaluate_response_exc: Exception | None = None,
+    ) -> None:
+        self.settings = settings
+        self._evaluate_result = evaluate_result
+        self._evaluate_response_result = evaluate_response_result
+        self._evaluate_exc = evaluate_exc
+        self._evaluate_response_exc = evaluate_response_exc
+
+    async def evaluate(self, *args, **kwargs) -> bool:
+        del args, kwargs
+        if self._evaluate_exc is not None:
+            raise self._evaluate_exc
+        return self._evaluate_result
+
+    async def evaluate_response(self, *args, **kwargs) -> bool:
+        del args, kwargs
+        if self._evaluate_response_exc is not None:
+            raise self._evaluate_response_exc
+        return self._evaluate_response_result
+
+    async def close(self) -> None:
+        return None
+
+
+def _build_action_service(
+    monkeypatch: pytest.MonkeyPatch,
+    settings_factory,
+    guardrail_service: _GuardrailStub,
+):
+    monkeypatch.setattr(action_module, "ZammadAPIClient", _DummyZammadClient)
+    settings = settings_factory(guardrails=guardrail_service.settings)
+    ai_action = Action(name="AI Answer", description="AI answer", type=ActionTypes.AIAnswer)
+    settings.triage.actions = [*settings.triage.actions, ai_action]
+    answer_service = AsyncMock()
+    answer_service.generate_answer = AsyncMock(
+        return_value=AnswerCandidate(
+            subject="S" * 50,
+            response="R" * 200,
+            documents=[],
+        )
+    )
+    return action_module.ActionService(
+        settings=settings,
+        answer_service=answer_service,
+        guardrail_service=cast(GuardrailService, guardrail_service),
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_answer_rejects_unsafe_input(monkeypatch: pytest.MonkeyPatch, settings_factory) -> None:
+    """Unsafe user input should raise a non-retryable action error."""
+    guardrail_service = _GuardrailStub(
+        GuardrailSettings(enabled=True, block_on_high_risk=True),
+        evaluate_result=False,
+    )
+    service = _build_action_service(monkeypatch, settings_factory, guardrail_service)
+
+    with pytest.raises(ActionExecutionError) as exc_info:
+        await service.get_answer(
+            ticket_id=1,
+            category_name="Unknown",
+            action_name="AI Answer",
+            user_text="x",
+            session_id=None,
+        )
+
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_get_answer_retries_on_input_guardrail_failure(
+    monkeypatch: pytest.MonkeyPatch, settings_factory
+) -> None:
+    """Guardrail evaluation failures before answer generation should be retryable."""
+    guardrail_service = _GuardrailStub(
+        GuardrailSettings(enabled=True, block_on_high_risk=True),
+        evaluate_exc=GuardrailEvaluationError("failed"),
+    )
+    service = _build_action_service(monkeypatch, settings_factory, guardrail_service)
+
+    with pytest.raises(ActionExecutionError) as exc_info:
+        await service.get_answer(
+            ticket_id=1,
+            category_name="Unknown",
+            action_name="AI Answer",
+            user_text="x",
+            session_id=None,
+        )
+
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_get_answer_rejects_unsafe_response(monkeypatch: pytest.MonkeyPatch, settings_factory) -> None:
+    """Unsafe generated responses should raise a non-retryable action error."""
+    guardrail_service = _GuardrailStub(
+        GuardrailSettings(enabled=True, block_on_high_risk=True),
+        evaluate_result=True,
+        evaluate_response_result=False,
+    )
+    service = _build_action_service(monkeypatch, settings_factory, guardrail_service)
+
+    with pytest.raises(ActionExecutionError) as exc_info:
+        await service.get_answer(
+            ticket_id=1,
+            category_name="Unknown",
+            action_name="AI Answer",
+            user_text="x",
+            session_id=None,
+        )
+
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_get_answer_retries_on_response_guardrail_failure(
+    monkeypatch: pytest.MonkeyPatch, settings_factory
+) -> None:
+    """Guardrail evaluation failures after answer generation should be retryable."""
+    guardrail_service = _GuardrailStub(
+        GuardrailSettings(enabled=True, block_on_high_risk=True),
+        evaluate_result=True,
+        evaluate_response_exc=GuardrailEvaluationError("failed"),
+    )
+    service = _build_action_service(monkeypatch, settings_factory, guardrail_service)
+
+    with pytest.raises(ActionExecutionError) as exc_info:
+        await service.get_answer(
+            ticket_id=1,
+            category_name="Unknown",
+            action_name="AI Answer",
+            user_text="x",
+            session_id=None,
+        )
+
+    assert exc_info.value.retryable is True

--- a/zammad-ai-workflow/test/test_dlf.py
+++ b/zammad-ai-workflow/test/test_dlf.py
@@ -1,0 +1,82 @@
+"""Tests for DLF retrieval guardrail behavior."""
+
+from typing import cast
+
+import httpx
+import pytest
+from pydantic import HttpUrl
+
+from app.answer.dlf import DLFClient
+from app.errors import DLFError
+from app.guardrails import GuardrailService
+from app.settings.answer import DLFSettings
+from app.settings.guardrails import GuardrailSettings
+
+
+class _GuardrailStub:
+    def __init__(self, settings: GuardrailSettings, result: bool) -> None:
+        self.settings = settings
+        self._result = result
+
+    async def evaluate(self, *args, **kwargs) -> bool:
+        del args, kwargs
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_retrieve_documents_allows_queries_when_guardrails_disabled() -> None:
+    """DLF should retrieve documents even if the guardrail result is false when guardrails are disabled."""
+    guardrail_service = _GuardrailStub(GuardrailSettings(enabled=False), result=False)
+    service = DLFClient(
+        DLFSettings(url=HttpUrl("http://testserver"), filter_categories=[]),
+        cast(GuardrailService, guardrail_service),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/retrieval"
+        return httpx.Response(
+            200,
+            json={
+                "retrieval_documents": [
+                    {
+                        "name": "  Example  ",
+                        "page_content": "Line 1\nLine 2  ",
+                        "metadata": {"source": "https://example.test/doc"},
+                    }
+                ]
+            },
+        )
+
+    service.__dict__["client"] = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://testserver",
+        timeout=2.0,
+    )
+
+    documents = await service.retrieve_documents("unsafe query")
+
+    assert len(documents) == 1
+    assert documents[0].title == "Example"
+    assert documents[0].content == "Line 1 Line 2"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_documents_blocks_unsafe_query_when_guardrails_enabled() -> None:
+    """DLF should raise a permanent error only for unsafe queries when guardrails are enabled."""
+    guardrail_service = _GuardrailStub(GuardrailSettings(enabled=True), result=False)
+    service = DLFClient(
+        DLFSettings(url=HttpUrl("http://testserver"), filter_categories=[]),
+        cast(GuardrailService, guardrail_service),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"Unexpected request to {request.url}")
+
+    service.__dict__["client"] = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="http://testserver",
+        timeout=2.0,
+    )
+
+    with pytest.raises(DLFError, match="Query flagged as unsafe by guardrails"):
+        await service.retrieve_documents("unsafe query")

--- a/zammad-ai-workflow/test/test_dlf.py
+++ b/zammad-ai-workflow/test/test_dlf.py
@@ -47,17 +47,21 @@ async def test_retrieve_documents_allows_queries_when_guardrails_disabled() -> N
             },
         )
 
+    await service.client.aclose()
     service.__dict__["client"] = httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://testserver",
         timeout=2.0,
     )
 
-    documents = await service.retrieve_documents("unsafe query")
+    try:
+        documents = await service.retrieve_documents("unsafe query")
 
-    assert len(documents) == 1
-    assert documents[0].title == "Example"
-    assert documents[0].content == "Line 1 Line 2"
+        assert len(documents) == 1
+        assert documents[0].title == "Example"
+        assert documents[0].content == "Line 1 Line 2"
+    finally:
+        await service.close()
 
 
 @pytest.mark.asyncio
@@ -72,11 +76,15 @@ async def test_retrieve_documents_blocks_unsafe_query_when_guardrails_enabled() 
     def handler(request: httpx.Request) -> httpx.Response:
         raise AssertionError(f"Unexpected request to {request.url}")
 
+    await service.client.aclose()
     service.__dict__["client"] = httpx.AsyncClient(
         transport=httpx.MockTransport(handler),
         base_url="http://testserver",
         timeout=2.0,
     )
 
-    with pytest.raises(DLFError, match="Query flagged as unsafe by guardrails"):
-        await service.retrieve_documents("unsafe query")
+    try:
+        with pytest.raises(DLFError, match="Query flagged as unsafe by guardrails"):
+            await service.retrieve_documents("unsafe query")
+    finally:
+        await service.close()

--- a/zammad-ai-workflow/test/test_guardrails.py
+++ b/zammad-ai-workflow/test/test_guardrails.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 from pydantic import HttpUrl
 
+from app.errors import GuardrailEvaluationError
 from app.guardrails import GuardrailService
 from app.settings.guardrails import GuardrailSettings
 
@@ -28,13 +29,13 @@ def guardrail_service(guardrail_settings: GuardrailSettings) -> GuardrailService
 
 @pytest.mark.asyncio
 async def test_guardrail_service_disabled() -> None:
-    """When disabled, guardrail client should return None."""
+    """When disabled, guardrail client should allow the request through."""
     settings = GuardrailSettings(enabled=False)
     service = GuardrailService(settings)
 
     result = await service.evaluate("any text")
 
-    assert result is False
+    assert result is True
 
 
 def test_guardrail_settings_defaults() -> None:
@@ -71,13 +72,13 @@ def test_guardrail_settings_block_on_high_risk() -> None:
 
 @pytest.mark.asyncio
 async def test_guardrail_response_disabled() -> None:
-    """When disabled, response guardrail should return None."""
+    """When disabled, response guardrail should allow the response through."""
     settings = GuardrailSettings(enabled=False)
     service = GuardrailService(settings)
 
     result = await service.evaluate_response("prompt", "response")
 
-    assert result is False
+    assert result is True
 
 
 @pytest.mark.asyncio
@@ -132,8 +133,8 @@ async def test_guardrail_http_response_success(guardrail_settings: GuardrailSett
 
 
 @pytest.mark.asyncio
-async def test_guardrail_http_error_fail_open(guardrail_settings: GuardrailSettings) -> None:
-    """Client fails with None on HTTP errors."""
+async def test_guardrail_http_error_raises_evaluation_error(guardrail_settings: GuardrailSettings) -> None:
+    """Client should raise a retryable evaluation error on HTTP failures."""
     service = GuardrailService(guardrail_settings)
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -142,11 +143,11 @@ async def test_guardrail_http_error_fail_open(guardrail_settings: GuardrailSetti
     transport = httpx.MockTransport(handler)
     service._client = httpx.AsyncClient(transport=transport, base_url="http://testserver", timeout=2.0)
 
-    result_prompt = await service.evaluate("text")
-    result_response = await service.evaluate_response("prompt", "response")
+    with pytest.raises(GuardrailEvaluationError):
+        await service.evaluate("text")
 
-    assert result_prompt is False
-    assert result_response is False
+    with pytest.raises(GuardrailEvaluationError):
+        await service.evaluate_response("prompt", "response")
 
 
 @pytest.mark.asyncio
@@ -162,7 +163,7 @@ async def test_guardrail_service_close_is_idempotent(guardrail_settings: Guardra
             self.calls += 1
 
     dummy_client = DummyClient()
-    service._client = dummy_client  # ty: ignore[invalid-assignment]
+    service.__dict__["_client"] = dummy_client
 
     await service.close()
     await service.close()

--- a/zammad-ai-workflow/test/test_guardrails.py
+++ b/zammad-ai-workflow/test/test_guardrails.py
@@ -5,7 +5,6 @@ import pytest
 from pydantic import HttpUrl
 
 from app.guardrails import GuardrailService
-from app.models.guardrails import GuardrailResponseResult, GuardrailResult
 from app.settings.guardrails import GuardrailSettings
 
 
@@ -35,7 +34,7 @@ async def test_guardrail_service_disabled() -> None:
 
     result = await service.evaluate("any text")
 
-    assert result is None
+    assert result is False
 
 
 def test_guardrail_settings_defaults() -> None:
@@ -78,7 +77,7 @@ async def test_guardrail_response_disabled() -> None:
 
     result = await service.evaluate_response("prompt", "response")
 
-    assert result is None
+    assert result is False
 
 
 @pytest.mark.asyncio
@@ -104,9 +103,7 @@ async def test_guardrail_http_prompt_success(guardrail_settings: GuardrailSettin
 
     result = await service.evaluate("some text")
 
-    assert isinstance(result, GuardrailResult)
-    assert result.prompt_safety == "unsafe"
-    assert "hate_and_discrimination" in result.prompt_toxicity
+    assert result is False
 
 
 @pytest.mark.asyncio
@@ -131,9 +128,7 @@ async def test_guardrail_http_response_success(guardrail_settings: GuardrailSett
 
     result = await service.evaluate_response("prompt", "response")
 
-    assert isinstance(result, GuardrailResponseResult)
-    assert result.response_safety == "unsafe"
-    assert "pii_exposure" in result.response_toxicity
+    assert result is False
 
 
 @pytest.mark.asyncio
@@ -150,8 +145,8 @@ async def test_guardrail_http_error_fail_open(guardrail_settings: GuardrailSetti
     result_prompt = await service.evaluate("text")
     result_response = await service.evaluate_response("prompt", "response")
 
-    assert result_prompt is None
-    assert result_response is None
+    assert result_prompt is False
+    assert result_response is False
 
 
 @pytest.mark.asyncio

--- a/zammad-ai-workflow/test/test_triage_guardrails.py
+++ b/zammad-ai-workflow/test/test_triage_guardrails.py
@@ -1,0 +1,101 @@
+"""Tests for guardrail mapping inside the triage service."""
+
+import pytest
+
+import app.triage.triage as triage_module
+from app.errors import GuardrailEvaluationError
+from app.settings.guardrails import GuardrailSettings
+from app.triage.triage import TriageError, TriageService
+
+
+class _DummyZammadClient:
+    def __init__(self, settings) -> None:
+        self.settings = settings
+
+    async def close(self) -> None:
+        return None
+
+
+class _DummyPreparserService:
+    def preparse(self, message: str) -> str:
+        return message
+
+
+class _DummyGenAIHandler:
+    def __init__(self, *args, **kwargs) -> None:
+        del args, kwargs
+
+    async def categorize_ticket(self, *args, **kwargs):
+        del args, kwargs
+        raise AssertionError("categorize_ticket should not be called in these tests")
+
+
+class _GuardrailStub:
+    def __init__(
+        self,
+        settings: GuardrailSettings,
+        *,
+        evaluate_result: bool = True,
+        evaluate_exc: Exception | None = None,
+    ) -> None:
+        self.settings = settings
+        self._evaluate_result = evaluate_result
+        self._evaluate_exc = evaluate_exc
+
+    async def evaluate(self, *args, **kwargs) -> bool:
+        del args, kwargs
+        if self._evaluate_exc is not None:
+            raise self._evaluate_exc
+        return self._evaluate_result
+
+    async def evaluate_response(self, *args, **kwargs) -> bool:
+        del args, kwargs
+        return True
+
+    async def close(self) -> None:
+        return None
+
+
+def _build_triage_service(
+    monkeypatch: pytest.MonkeyPatch,
+    settings_factory,
+    guardrail_service: _GuardrailStub,
+) -> TriageService:
+    monkeypatch.setattr(triage_module, "GenAIHandler", _DummyGenAIHandler)
+    monkeypatch.setattr(triage_module, "ZammadAPIClient", _DummyZammadClient)
+    monkeypatch.setattr(triage_module, "get_preparser_service", lambda *args, **kwargs: _DummyPreparserService())
+    monkeypatch.setattr(triage_module, "get_guardrail_service", lambda settings: guardrail_service)
+    settings = settings_factory(guardrails=guardrail_service.settings)
+    return TriageService(settings=settings)
+
+
+@pytest.mark.asyncio
+async def test_predict_category_rejects_unsafe_input(monkeypatch: pytest.MonkeyPatch, settings_factory) -> None:
+    """Unsafe input should raise a non-retryable triage error."""
+    guardrail_service = _GuardrailStub(
+        GuardrailSettings(enabled=True, block_on_high_risk=True),
+        evaluate_result=False,
+    )
+    service = _build_triage_service(monkeypatch, settings_factory, guardrail_service)
+
+    with pytest.raises(TriageError) as exc_info:
+        await service.predict_category(message="x", session_id="session-id")
+
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_predict_category_retries_on_guardrail_failure(
+    monkeypatch: pytest.MonkeyPatch, settings_factory
+) -> None:
+    """Guardrail evaluation failures should be retryable."""
+    guardrail_service = _GuardrailStub(
+        GuardrailSettings(enabled=True, block_on_high_risk=True),
+        evaluate_exc=GuardrailEvaluationError("failed"),
+    )
+    service = _build_triage_service(monkeypatch, settings_factory, guardrail_service)
+
+    with pytest.raises(TriageError) as exc_info:
+        await service.predict_category(message="x", session_id="session-id")
+
+    assert exc_info.value.retryable is True


### PR DESCRIPTION
Should we accept unsafe + benign/benign ???

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guardrail handling by clearly distinguishing unsafe content from evaluation failures.
  * Unsafe inputs, generated responses, and document searches are blocked when protection is enabled.
  * Guardrail service failures now trigger retryable errors, improving recovery during temporary issues.
  * Simplified and standardized safety decisions across response generation, document retrieval, and category prediction.
* **Tests**
  * Expanded coverage for safe, unsafe, disabled, and failed guardrail evaluations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->