### PR TITLE
feat(agent): enable expected tool failures handling in agent context

### DIFF
--- a/zammad-ai-workflow/app/answer/agent.py
+++ b/zammad-ai-workflow/app/answer/agent.py
@@ -43,6 +43,12 @@ class AgentContext(BaseModel):
     }
 
 
+def _enable_expected_tool_failures(tool: BaseTool) -> BaseTool:
+    """Return a tool configured to surface expected failures back to the agent."""
+    tool.handle_tool_error = True
+    return tool
+
+
 @tool(
     "search_website",
     description="Search the city of munich website including all public service descriptions and information articles for relevant documents. Never append personal information to the query.",
@@ -201,7 +207,7 @@ def build_law_tool(law: LawToolSettings) -> BaseTool:
             logger.error("Error retrieving law documents from Qdrant", exc_info=True)
             raise ToolException(f"Failed to retrieve documents from {law_name}") from e
 
-    return search_law
+    return _enable_expected_tool_failures(search_law)
 
 
 def build_agent(
@@ -227,10 +233,10 @@ def build_agent(
 
     # Configure the tools
     available_tools: list[BaseTool] = [
-        search_knowledgebase,
+        _enable_expected_tool_failures(search_knowledgebase),
     ]
     if dlf_enabled:
-        available_tools.append(search_dlf)
+        available_tools.append(_enable_expected_tool_failures(search_dlf))
     for law in laws or []:
         available_tools.append(build_law_tool(law))
 

--- a/zammad-ai-workflow/test/test_answer_agent.py
+++ b/zammad-ai-workflow/test/test_answer_agent.py
@@ -1,0 +1,35 @@
+"""Tests for answer agent wiring."""
+
+from typing import Any
+
+from app.answer.agent import build_agent
+from app.settings.answer import LawToolSettings
+from app.settings.genai import GenAIOpenAISettings
+
+
+def test_build_agent_enables_expected_tool_failures(monkeypatch) -> None:
+    """Answer tools should surface expected failures back to the agent."""
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    def fake_create_agent(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr("app.answer.agent.create_agent", fake_create_agent)
+    monkeypatch.setattr("app.answer.agent.get_chat_model", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        "app.answer.agent.build_knowledgebase_middleware",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    result = build_agent(
+        genai_settings=GenAIOpenAISettings(),
+        agent_prompt="system prompt",
+        dlf_enabled=True,
+        laws=[LawToolSettings(id="fev", name="Fahrerlaubnis-Verordnung")],
+    )
+
+    assert result is sentinel
+    tools = captured["tools"]
+    assert [tool.handle_tool_error for tool in tools] == [True, True, True]


### PR DESCRIPTION
Closes #369 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Expected tool failures are now returned to the AI agent for handling, improving responses when tools encounter expected errors.
  - This behavior applies to law, knowledge base, and DLF search tools.

- **Tests**
  - Added automated coverage to verify that expected tool failures are enabled across configured agent tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->