### PR TITLE
feat(kafka): add max workers for concurency

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -75,7 +75,9 @@ services:
       kafka-topics --bootstrap-server kafka:9092 --list
 
       echo -e 'Creating kafka topics...'
-      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic ticket-events --replication-factor 1 --partitions 1
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic ticket-events --replication-factor 1 --partitions 5
+
+      kafka-topics --bootstrap-server kafka:9092 --create --if-not-exists --topic ticket-events-retry --replication-factor 1 --partitions 5
 
       echo -e 'Resulting topics:'
       kafka-topics --bootstrap-server kafka:9092 --list

--- a/docs/components/kafka.md
+++ b/docs/components/kafka.md
@@ -49,6 +49,8 @@ kafka:
   retry_delay_seconds: 300
   max_retry_attempts: 3
 
+  max_workers: 5 # Maximum number of concurrent workers for processing events
+
   # Security: choose one schema and set the discriminator `type` to `env` or `file`.
   security:
     type: env

--- a/zammad-ai-workflow/app/kafka/broker.py
+++ b/zammad-ai-workflow/app/kafka/broker.py
@@ -231,6 +231,7 @@ def build_router(settings: ZammadAISettings) -> tuple[KafkaRouter, Callable]:
         settings.kafka.topic,
         group_id=settings.kafka.group_id,
         ack_policy=AckPolicy.NACK_ON_ERROR,
+        max_workers=settings.kafka.max_workers,
     )
     async def event_handler(event: Event | dict[str, object]) -> None:
         """Process a Kafka event from the main topic."""
@@ -283,6 +284,7 @@ def build_router(settings: ZammadAISettings) -> tuple[KafkaRouter, Callable]:
     @router.subscriber(
         settings.kafka.retry_topic,
         group_id=settings.kafka.group_id,
+        max_workers=settings.kafka.max_workers,
         ack_policy=AckPolicy.NACK_ON_ERROR,
     )
     async def retry_event_handler(

--- a/zammad-ai-workflow/app/settings/kafka.py
+++ b/zammad-ai-workflow/app/settings/kafka.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, FilePath, NonNegativeInt
+from pydantic import BaseModel, Field, FilePath, NonNegativeInt, PositiveInt
 
 
 class KafkaSettings(BaseModel):
@@ -57,7 +57,7 @@ class KafkaSettings(BaseModel):
         description="Settings related to processing of incoming events.",
         default_factory=lambda: EventProcessingSettings(),
     )
-    max_workers: NonNegativeInt = Field(
+    max_workers: PositiveInt = Field(
         description="Maximum number of concurrent workers for processing events.",
         default=5,
     )

--- a/zammad-ai-workflow/app/settings/kafka.py
+++ b/zammad-ai-workflow/app/settings/kafka.py
@@ -57,6 +57,10 @@ class KafkaSettings(BaseModel):
         description="Settings related to processing of incoming events.",
         default_factory=lambda: EventProcessingSettings(),
     )
+    max_workers: NonNegativeInt = Field(
+        description="Maximum number of concurrent workers for processing events.",
+        default=5,
+    )
 
 
 class EventProcessingSettings(BaseModel):

--- a/zammad-ai-workflow/app/settings/triage.py
+++ b/zammad-ai-workflow/app/settings/triage.py
@@ -257,3 +257,6 @@ class LangfusePrompt(BaseModel):
         description="Name of the prompt in Langfuse",
         examples=["use_case/triage/prompt_name"],
     )
+
+
+TriageSettings.model_rebuild()

--- a/zammad-ai-workflow/config.example.yaml
+++ b/zammad-ai-workflow/config.example.yaml
@@ -162,6 +162,8 @@ kafka:
   topic: "ticket-events" # Kafka topic to consume from
   client_id: "zammad-ai" # Kafka client ID shown as the consumer name
   group_id: null # Consumer group ID (defaults to null)
+  max_workers: 5 # Maximum number of concurrent workers for processing events
+  retry_topic: "ticket-events-retry" # Kafka topic for retrying failed events
   event_processing:
     valid_request_types: [] # List of request types to process (example: ["support"])
     valid_action_types: [] # List of action types to process (example: ["created", "updated"])

--- a/zammad-ai-workflow/pyproject.toml
+++ b/zammad-ai-workflow/pyproject.toml
@@ -2,7 +2,7 @@
 name = "zammad-ai-workflow"
 license = "MIT"
 
-version = "0.4.1"
+version = "0.4.6"
 
 description = "GenAI-powered agent for Zammad"
 readme = "README.md"

--- a/zammad-ai-workflow/uv.lock
+++ b/zammad-ai-workflow/uv.lock
@@ -2797,7 +2797,7 @@ wheels = [
 
 [[package]]
 name = "zammad-ai-workflow"
-version = "0.4.1"
+version = "0.4.6"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable concurrent processing for Kafka events, with up to five workers by default.
  * Added a dedicated retry topic for failed ticket events.
  * Kafka topics now support five partitions to improve event-processing capacity.
* **Documentation**
  * Updated configuration examples with worker-count and retry-topic settings.
* **Chores**
  * Updated the application version from 0.4.1 to 0.4.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->